### PR TITLE
Actualiza versión del paquete a 1.1.4

### DIFF
--- a/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
+++ b/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
@@ -20,7 +20,7 @@
 	  <Copyright>Mozilla Public License Version 2.0</Copyright>
 	  <PackageLicenseExpression> MPL-2.0</PackageLicenseExpression>
 	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-	  <Version>1.1.3</Version>
+	  <Version>1.1.4</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Se ha cambiado la versión del paquete en el archivo `MauiPdfGenerator.SourceGenerators.csproj` de `1.1.3` a `1.1.4`.