### PR TITLE
Actualiza versiones de paquetes en archivos de proyecto

### DIFF
--- a/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
+++ b/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
@@ -20,7 +20,7 @@
 	  <Copyright>Mozilla Public License Version 2.0</Copyright>
 	  <PackageLicenseExpression> MPL-2.0</PackageLicenseExpression>
 	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-	  <Version>1.1.4</Version>
+	  <Version>1.1.5</Version>
 	  <AssemblyVersion>1.0.5</AssemblyVersion>
 	  <FileVersion>1.0.5</FileVersion>
   </PropertyGroup>

--- a/MauiPdfGenerator/MauiPdfGenerator.csproj
+++ b/MauiPdfGenerator/MauiPdfGenerator.csproj
@@ -25,7 +25,7 @@
 		<PackageTags>.NET MAUI; PDF; SkiaSharp;</PackageTags>
 		<PackageLicenseExpression> MPL-2.0</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.4.1</Version>
+		<Version>1.4.2</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Se ha actualizado la versión del paquete en `MauiPdfGenerator.SourceGenerators.csproj` de `1.1.4` a `1.1.5` y en `MauiPdfGenerator.csproj` de `1.4.1` a `1.4.2`. Las expresiones de licencia y otros metadatos se han mantenido sin cambios significativos.