### PR TITLE
Añadir PackageId al proyecto MauiPdfGenerator

### DIFF
--- a/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
+++ b/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
@@ -25,6 +25,7 @@
 	  <FileVersion></FileVersion>
 	  <Company>RandAMediaLabGroup</Company>
 	  <Authors>cl2raul66</Authors>
+	  <PackageId>MauiPdfGenerator.SourceGenerators</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Se ha añadido la línea `<PackageId>MauiPdfGenerator.SourceGenerators</PackageId>` al archivo de proyecto `MauiPdfGenerator.SourceGenerators.csproj` para especificar el identificador del paquete del generador de PDF de Maui.