### PR TITLE
Actualiza el identificador del paquete en el proyecto

### DIFF
--- a/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
+++ b/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
@@ -25,7 +25,7 @@
 	  <FileVersion></FileVersion>
 	  <Company>RandAMediaLabGroup</Company>
 	  <Authors>cl2raul66</Authors>
-	  <PackageId>MauiPdfGenerator.SourceGenerators</PackageId>
+	  <PackageId>RandAMediaLabGroup.MauiPdfGenerator.SourceGenerators</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Se ha cambiado el identificador del paquete de `MauiPdfGenerator.SourceGenerators` a `RandAMediaLabGroup.MauiPdfGenerator.SourceGenerators` en el archivo `MauiPdfGenerator.SourceGenerators.csproj` para reflejar mejor la propiedad y la relación con la empresa RandAMediaLabGroup.