### PR TITLE
Actualiza versiones de paquetes y añade PackageId

### DIFF
--- a/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
+++ b/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
@@ -20,7 +20,7 @@
 	  <Copyright>Mozilla Public License Version 2.0</Copyright>
 	  <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
 	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-	  <Version>1.1.8</Version>
+	  <Version>1.1.9</Version>
 	  <AssemblyVersion></AssemblyVersion>
 	  <FileVersion></FileVersion>
 	  <Company>RandAMediaLabGroup</Company>

--- a/MauiPdfGenerator/MauiPdfGenerator.csproj
+++ b/MauiPdfGenerator/MauiPdfGenerator.csproj
@@ -25,9 +25,10 @@
 		<PackageTags>.NET MAUI; PDF; SkiaSharp;</PackageTags>
 		<PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.4.3</Version>
+		<Version>1.4.4</Version>
 		<Authors>cl2raul66</Authors>
 		<Company>RandAMediaLabGroup</Company>
+		<PackageId>RandAMediaLabGroup.MauiPdfGenerator</PackageId>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Se ha actualizado la versión del paquete en `MauiPdfGenerator.SourceGenerators.csproj` de `1.1.8` a `1.1.9` y en `MauiPdfGenerator.csproj` de `1.4.3` a `1.4.4`. Además, se ha añadido el `PackageId` en `MauiPdfGenerator.csproj`, que ahora es `RandAMediaLabGroup.MauiPdfGenerator`.