### PR TITLE
Mejoras en la generación de alias de fuentes y ajustes

### DIFF
--- a/MauiPdfGenerator.SourceGenerators/FontAliasGenerator.cs
+++ b/MauiPdfGenerator.SourceGenerators/FontAliasGenerator.cs
@@ -2,169 +2,217 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable; // Necesario para ImmutableArray
+using System.Collections.Immutable;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Linq;
+using System.Collections.Generic;
+// Asegúrate de tener esta directiva si usas Debug.WriteLine (opcional, pero útil):
+using System.Diagnostics;
 
-namespace MauiPdfGenerator.SourceGenerators;
-
-[Generator]
-public class FontAliasGenerator : IIncrementalGenerator
-{
-    public void Initialize(IncrementalGeneratorInitializationContext context)
-    {
-        // PASO 1: Filtrar nodos de sintaxis para encontrar posibles candidatos
-        // Buscamos expresiones de invocación que podrían ser llamadas a AddFont
-        IncrementalValuesProvider<InvocationExpressionSyntax> invocationExpressions = context.SyntaxProvider
-            .CreateSyntaxProvider(
-                predicate: static (node, _) => IsSyntaxTargetForGeneration(node), // Filtro rápido inicial
-                transform: static (ctx, ct) => GetSemanticTargetForGeneration(ctx, ct)) // Obtener el nodo relevante si pasa el filtro semántico
-            .Where(static m => m is not null)!; // Filtra los nulos donde la transformación no encontró un objetivo válido
-
-        // PASO 2: Combinar los resultados con la compilación
-        // Esto permite usar el modelo semántico si es necesario (aunque aquí nos basamos en sintaxis)
-        IncrementalValueProvider<(Compilation, ImmutableArray<InvocationExpressionSyntax>)> compilationAndInvocations
-            = context.CompilationProvider.Combine(invocationExpressions.Collect());
-
-        // PASO 3: Generar el código fuente
-        context.RegisterSourceOutput(compilationAndInvocations,
-            static (spc, source) => Execute(source.Item1, source.Item2, spc));
-    }
-
-    /// <summary>
-    /// Filtro rápido inicial: ¿Podría este nodo ser una llamada a AddFont?
-    /// </summary>
-    static bool IsSyntaxTargetForGeneration(SyntaxNode node)
-    {
-        // Solo nos interesan las llamadas a métodos (InvocationExpressionSyntax)
-        return node is InvocationExpressionSyntax ies &&
-               // Cuyo nombre *podría* ser AddFont (no distingue mayúsculas/minúsculas aquí para ser más permisivo inicialmente)
-               ies.Expression is MemberAccessExpressionSyntax maes &&
-               maes.Name.Identifier.Text.Equals("AddFont", StringComparison.OrdinalIgnoreCase);
-        // Podríamos añadir más heurísticas si fuera necesario
-    }
-
-    /// <summary>
-    /// Filtro semántico (opcional pero bueno): ¿Es realmente la llamada AddFont que buscamos
-    /// y tiene los argumentos correctos?
-    /// </summary>
-    static InvocationExpressionSyntax? GetSemanticTargetForGeneration(GeneratorSyntaxContext context, CancellationToken ct)
-    {
-        var invocationExpr = (InvocationExpressionSyntax)context.Node;
-
-        // Aquí podríamos usar el modelo semántico (context.SemanticModel) para verificar
-        // el tipo al que pertenece AddFont, los tipos de los argumentos, etc.
-        // Por ahora, nos quedaremos con la lógica sintáctica que teníamos en el ISyntaxReceiver
-        // por simplicidad, pero esta es la ubicación correcta para el análisis semántico.
-
-        if (invocationExpr.ArgumentList is not null &&
-            invocationExpr.ArgumentList.Arguments.Count == 2)
-        {
-            var aliasArgument = invocationExpr.ArgumentList.Arguments[1]; // El segundo argumento
-
-            // Asegurarse de que sea una cadena literal
-            if (aliasArgument.Expression is LiteralExpressionSyntax literalExpr &&
-                literalExpr.IsKind(SyntaxKind.StringLiteralExpression))
-            {
-                // Devuelve el nodo de invocación si cumple los criterios sintácticos básicos
-                return invocationExpr;
-            }
-        }
-
-        // No es el objetivo que buscamos
-        return null;
-    }
-
-    /// <summary>
-    /// Método principal donde se extraen los alias y se genera el código.
-    /// </summary>
-    static void Execute(Compilation compilation, ImmutableArray<InvocationExpressionSyntax> invocations, SourceProductionContext context)
-    {
-        // Si el token de cancelación lo indica, salir temprano
-        context.CancellationToken.ThrowIfCancellationRequested();
-
-        if (invocations.IsDefaultOrEmpty)
-        {
-            // No se encontraron invocaciones candidatas
-            return;
-        }
-
-        // Usar un HashSet para evitar duplicados de alias
-        var discoveredAliases = new HashSet<string>();
-
-        foreach (var invocationExpr in invocations)
-        {
-            // Extraer el alias (ya sabemos que tiene 2 args y el 2do es string literal
-            // gracias a GetSemanticTargetForGeneration)
-            var aliasArgument = invocationExpr.ArgumentList!.Arguments[1];
-            var literalExpr = (LiteralExpressionSyntax)aliasArgument.Expression!;
-            string alias = literalExpr.Token.ValueText;
-
-            if (!string.IsNullOrWhiteSpace(alias))
-            {
-                discoveredAliases.Add(alias);
-            }
-        }
-
-        // Si no se descubrieron alias válidos, no generar archivo
-        if (!discoveredAliases.Any())
-            return;
-
-        // Construir el código fuente (igual que antes)
-        var sourceBuilder = new StringBuilder(@"// <auto-generated/>
-#pragma warning disable
+// El namespace del PROYECTO GENERADOR (Biblioteca .NET Standard 2.0)
 namespace MauiPdfGenerator.SourceGenerators
 {
+    [Generator]
+    public class FontAliasGenerator : IIncrementalGenerator
+    {
+        // Lista de las 14 fuentes PDF estándar Base14.
+        // Fuente: PDF 1.7 Specification, Section 5.5.1 Standard Type 1 Fonts
+        private static readonly ImmutableArray<string> StandardPdfBase14Fonts = ImmutableArray.Create(
+            // Times
+            "Times-Roman",
+            "Times-Bold",
+            "Times-Italic",
+            "Times-BoldItalic",
+            // Helvetica (equivalente a Arial en muchos sistemas)
+            "Helvetica",
+            "Helvetica-Bold",
+            "Helvetica-Oblique", // Equivalente a Italic
+            "Helvetica-BoldOblique",
+            // Courier (monoespaciada)
+            "Courier",
+            "Courier-Bold",
+            "Courier-Oblique",
+            "Courier-BoldOblique",
+            // Symbolos
+            "Symbol",
+            "ZapfDingbats"
+        );
+
+        // El namespace donde se generará la clase de alias en el proyecto MAUI
+        private const string OutputNamespace = "MauiPdfGenerator.Generated";
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            // PASO 1: Encontrar invocaciones .AddFont(file, alias)
+            // Usamos la lógica que YA TE FUNCIONA gracias a Claude
+            IncrementalValuesProvider<InvocationExpressionSyntax> potentialAddFontCalls = context.SyntaxProvider
+                .CreateSyntaxProvider(
+                    predicate: static (node, _) => IsPotentialAddFontCall(node), // El predicado que funcionó
+                    transform: static (ctx, ct) => GetValidAddFontCallIfCorrect(ctx, ct)) // La transformación que funcionó
+                .Where(static m => m is not null)!;
+
+            // PASO 2: Combinar con la compilación
+            IncrementalValueProvider<(Compilation, ImmutableArray<InvocationExpressionSyntax>)> compilationAndInvocations
+                = context.CompilationProvider.Combine(potentialAddFontCalls.Collect());
+
+            // PASO 3: Generar el código fuente
+            context.RegisterSourceOutput(compilationAndInvocations,
+                static (spc, source) => GenerateAliasesClass(source.Item1, source.Item2, spc));
+
+            // Puedes mantener o quitar la salida de diagnóstico de Claude si ya no la necesitas
+            // context.RegisterPostInitializationOutput(ctx => { /* ... código diagnóstico ... */ });
+        }
+
+        // --- MÉTODOS DE DETECCIÓN (USA LOS QUE TE FUNCIONARON) ---
+        // Estos métodos deben ser exactamente los que Claude te dio y que
+        // confirmaste que funcionaban para detectar las fuentes de tu MAUI App.
+
+        static bool IsPotentialAddFontCall(SyntaxNode node)
+        {
+            // Lógica de Claude que funcionó (probablemente similar a esto):
+            return node is InvocationExpressionSyntax ies &&
+                  ies.Expression is MemberAccessExpressionSyntax maes &&
+                  maes.Name.Identifier.Text.Equals("AddFont", StringComparison.OrdinalIgnoreCase); // O Ordinal si funcionó así
+        }
+
+        static InvocationExpressionSyntax? GetValidAddFontCallIfCorrect(GeneratorSyntaxContext context, CancellationToken ct)
+        {
+            // Lógica de Claude que funcionó (probablemente similar a esto):
+            var invocationExpr = (InvocationExpressionSyntax)context.Node;
+            if (invocationExpr.ArgumentList is not null &&
+                invocationExpr.ArgumentList.Arguments.Count == 2)
+            {
+                var aliasArgument = invocationExpr.ArgumentList.Arguments[1];
+                if (aliasArgument.Expression is LiteralExpressionSyntax literalExpr &&
+                    literalExpr.IsKind(SyntaxKind.StringLiteralExpression))
+                {
+                    if (!string.IsNullOrWhiteSpace(literalExpr.Token.ValueText))
+                    {
+                        return invocationExpr;
+                    }
+                }
+            }
+            return null;
+        }
+
+        // --- GENERACIÓN DEL CÓDIGO (MODIFICADO PARA INCLUIR ESTÁNDAR) ---
+
+        static void GenerateAliasesClass(Compilation compilation, ImmutableArray<InvocationExpressionSyntax> discoveredInvocations, SourceProductionContext context)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            Debug.WriteLine($"[FontAliasGenerator] Starting GenerateAliasesClass. Discovered invocations count: {discoveredInvocations.Length}");
+
+            // Usar HashSet para manejar duplicados automáticamente (estándar vs descubiertas, y descubiertas entre sí)
+            // Usar StringComparer.Ordinal para ser sensible a mayúsculas/minúsculas (como MAUI)
+            var finalAliases = new HashSet<string>(StringComparer.Ordinal);
+
+            // 1. Añadir siempre las fuentes estándar PDF Base14
+            foreach (var stdFont in StandardPdfBase14Fonts)
+            {
+                // No debería haber nulos/blancos, pero por seguridad
+                if (!string.IsNullOrWhiteSpace(stdFont))
+                {
+                    finalAliases.Add(stdFont);
+                    // Debug.WriteLine($"[FontAliasGenerator] Added standard font: {stdFont}");
+                }
+            }
+            Debug.WriteLine($"[FontAliasGenerator] Alias count after standard fonts: {finalAliases.Count}");
+
+            // 2. Añadir las fuentes descubiertas del proyecto MAUI (si las hay)
+            if (!discoveredInvocations.IsDefaultOrEmpty)
+            {
+                foreach (var invocationExpr in discoveredInvocations)
+                {
+                    // Extraer alias (asumiendo que GetValidAddFontCallIfCorrect ya validó)
+                    var aliasArgument = invocationExpr.ArgumentList!.Arguments[1];
+                    var literalExpr = (LiteralExpressionSyntax)aliasArgument.Expression!;
+                    string discoveredAlias = literalExpr.Token.ValueText; // Ya sin comillas
+
+                    // Add devolverá true si se añadió, false si ya existía
+                    bool added = finalAliases.Add(discoveredAlias);
+                    // if (added) Debug.WriteLine($"[FontAliasGenerator] Added discovered font: {discoveredAlias}");
+                    // else Debug.WriteLine($"[FontAliasGenerator] Discovered font '{discoveredAlias}' already exists.");
+                }
+            }
+            else
+            {
+                Debug.WriteLine("[FontAliasGenerator] No discovered AddFont invocations from MAUI project.");
+            }
+
+            Debug.WriteLine($"[FontAliasGenerator] Total final unique aliases: {finalAliases.Count}");
+
+            // Si no hay NINGÚN alias (ni estándar ni descubierto), no generar archivo.
+            // Esto es improbable si StandardPdfBase14Fonts tiene elementos.
+            if (!finalAliases.Any())
+            {
+                Debug.WriteLine("[FontAliasGenerator] No aliases to generate. Skipping file output.");
+                return;
+            }
+
+            // Generar el código fuente usando el namespace de salida correcto
+            string sourceCode = GenerateSourceCodeString(finalAliases);
+            context.AddSource("MauiFontAliases.g.cs", SourceText.From(sourceCode, Encoding.UTF8));
+            Debug.WriteLine("[FontAliasGenerator] MauiFontAliases.g.cs source added to compilation.");
+        }
+
+        private static string GenerateSourceCodeString(HashSet<string> aliases)
+        {
+            // Usamos el namespace OutputNamespace definido arriba ("MauiPdfGenerator.Generated")
+            var sourceBuilder = new StringBuilder($@"// <auto-generated/>
+// Generated by MauiPdfGenerator.SourceGenerators.FontAliasGenerator
+#pragma warning disable
+namespace {OutputNamespace} // Namespace para la CLASE GENERADA
+{{
     /// <summary>
-    /// Provides compile-time safe constants for font aliases potentially registered
-    /// via .AddFont(file, alias) in the MAUI application.
-    /// Generated by MauiPdfGenerator.SourceGenerators.
+    /// Provides compile-time safe constants for font aliases.
+    /// Includes standard PDF Base14 fonts and fonts registered via .AddFont(file, alias)
+    /// in the MAUI application. Generated by MauiPdfGenerator.SourceGenerators.
     /// </summary>
     public static class MauiFontAliases
-    {
+    {{
 ");
+            // Usar Ordinal para evitar colisiones de identificadores C# si los alias solo difieren en mayúsculas/minúsculas
+            // pero generan el mismo identificador (ej. "My_Font" y "my_font" -> My_Font)
+            var generatedIdentifiers = new HashSet<string>(StringComparer.Ordinal);
 
-        var generatedIdentifiers = new HashSet<string>();
-
-        // Ordenar alfabéticamente para una salida consistente
-        foreach (string alias in discoveredAliases.OrderBy(a => a))
-        {
-            string identifier = CreateValidIdentifier(alias);
-
-            if (generatedIdentifiers.Add(identifier))
+            // Ordenar alfabéticamente (ignorando mayúsculas) para una salida consistente
+            foreach (string alias in aliases.OrderBy(a => a, StringComparer.OrdinalIgnoreCase))
             {
-                sourceBuilder.AppendLine($"        /// <summary>Alias for font '{alias}'.</summary>");
-                sourceBuilder.AppendLine($"        public const string {identifier} = \"{alias}\";");
-                sourceBuilder.AppendLine();
+                string identifier = CreateValidIdentifier(alias);
+                if (generatedIdentifiers.Add(identifier)) // Solo añadir si el IDENTIFICADOR es nuevo
+                {
+                    string escapedAlias = System.Security.SecurityElement.Escape(alias) ?? alias;
+                    sourceBuilder.AppendLine($"        /// <summary>Font alias constant for '{escapedAlias}'. Value: \"{alias}\"</summary>");
+                    // El valor de la constante es el alias ORIGINAL (sensible a mayúsculas)
+                    sourceBuilder.AppendLine($"        public const string {identifier} = \"{alias}\";");
+                    sourceBuilder.AppendLine();
+                }
+                else
+                {
+                    // Opcional: Podrías loggear o añadir un diagnóstico si se omite un identificador duplicado
+                    Debug.WriteLine($"[FontAliasGenerator] Skipping duplicate identifier '{identifier}' for alias '{alias}'.");
+                }
             }
+            sourceBuilder.AppendLine("    }"); // Fin clase
+            sourceBuilder.AppendLine("}"); // Fin namespace
+            sourceBuilder.AppendLine("#pragma warning restore");
+            return sourceBuilder.ToString();
         }
 
-        sourceBuilder.AppendLine("    }");
-        sourceBuilder.AppendLine("}");
-        sourceBuilder.AppendLine("#pragma warning restore");
-
-        // Añade el archivo generado a la compilación
-        context.AddSource("MauiFontAliases.g.cs", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
-    }
-
-    // El método CreateValidIdentifier permanece igual que antes
-    private static string CreateValidIdentifier(string input)
-    {
-        if (string.IsNullOrWhiteSpace(input))
-            return "_";
-
-        string identifier = input.Trim();
-        identifier = Regex.Replace(identifier, @"[^a-zA-Z0-9_]", "_");
-
-        if (char.IsDigit(identifier[0]))
+        // --- MÉTODO UTILITARIO (USA EL QUE TE FUNCIONÓ) ---
+        private static string CreateValidIdentifier(string input)
         {
-            identifier = "_" + identifier;
+            // Lógica de Claude que funcionó (probablemente similar a esto):
+            if (string.IsNullOrWhiteSpace(input)) return "_";
+            string identifier = input.Trim();
+            identifier = Regex.Replace(identifier, @"[^\p{L}\p{N}_]", "_"); // Permitir letras Unicode, números, _
+            if (identifier.Length > 0 && char.IsDigit(identifier[0])) identifier = "_" + identifier;
+            else if (string.IsNullOrEmpty(identifier.Replace("_", ""))) return "_"; // Si solo quedan '_' o vacío
+            // Comprobar palabras clave C#
+            if (SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None || SyntaxFacts.GetContextualKeywordKind(identifier) != SyntaxKind.None)
+                identifier = "@" + identifier;
+            return identifier;
         }
-        // Opcional: Comprobar palabras clave (menos probable para fuentes)
-        // if (SyntaxFacts.IsKeywordKind(SyntaxFacts.GetKeywordKind(identifier))) identifier = "@" + identifier;
-
-        return identifier;
     }
 }
-
-

--- a/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
+++ b/MauiPdfGenerator.SourceGenerators/MauiPdfGenerator.SourceGenerators.csproj
@@ -8,7 +8,9 @@
 	  <LangVersion>latest</LangVersion>
 
 	  <IsRoslynAnalyzer>true</IsRoslynAnalyzer>
+	  <!--<IncludeBuildOutput>false</IncludeBuildOutput>-->
 	  <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+	  
 	  <ApplicationIcon>logo.ico</ApplicationIcon>
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <Title>MauiPdfGenerator.SourceGenerators</Title>
@@ -20,7 +22,7 @@
 	  <Copyright>Mozilla Public License Version 2.0</Copyright>
 	  <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
 	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-	  <Version>1.1.10</Version>
+	  <Version>1.2.0</Version>
 	  <AssemblyVersion></AssemblyVersion>
 	  <FileVersion></FileVersion>
 	  <Company>RandAMediaLabGroup</Company>

--- a/Test/MainPage.xaml.cs
+++ b/Test/MainPage.xaml.cs
@@ -1,14 +1,14 @@
-﻿using MauiPdfGenerator;
+﻿using Microsoft.Maui.Controls;
+using System.Diagnostics;
+using MauiPdfGenerator;
 using static Microsoft.Maui.Graphics.Colors;
 using static Microsoft.Maui.Controls.FontAttributes;
 using static Microsoft.Maui.LineBreakMode;
 using static Microsoft.Maui.TextAlignment;
 using static MauiPdfGenerator.Fluent.Enums.PageSizeType;
 using static MauiPdfGenerator.Fluent.Enums.DefaultMarginType;
-using static MauiPdfGenerator.SourceGenerators.MauiFontAliases;
+using static MauiPdfGenerator.Generated.MauiFontAliases;
 using static MauiPdfGenerator.Fluent.Enums.PageOrientationType;
-using System.Reflection;
-using Microsoft.Maui.Graphics.Platform;
 
 namespace Test;
 
@@ -40,18 +40,21 @@ public partial class MainPage : ContentPage
                     });
                 })
                 .ContentPage()
-                .DefaultFont(f => f.Size(10))
+                .DefaultFont(f => f.Family("Helvetica").Size(10))
                 .Spacing(8f)
                 .Content(c =>
                 {
                     c.Paragraph("Text Wrapping Demonstration")
-                         .FontSize(16f)
-                         .FontAttributes(Bold)
-                         .Alignment(End);
+                        .FontSize(16f)
+                        .FontFamily("Helvetica")
+                        .FontAttributes(Bold)
+                        .Alignment(End);
                     c.HorizontalLine();
-                    c.Paragraph("Default (WordWrap): This is a relatively long sentence designed to test the default word wrapping behavior which should break lines at spaces.");
+                    c.Paragraph("Default (WordWrap): This is a relatively long sentence designed to test the default word wrapping behavior which should break lines at spaces.")
+                        .FontFamily(OpenSansRegular);
                     c.Paragraph("CharacterWrap: This_very_long_unbroken_string_will_demonstrate_CharacterWrap and This_very_long_unbroken_string_will_demonstrate_CharacterWrap, breakingmidword.")
-                         .LineBreakMode(CharacterWrap);
+                        .FontFamily("Courier")
+                        .LineBreakMode(CharacterWrap);
                     c.Paragraph("CharacterWrap: This_very_long_unbroken_string_will_demonstrate_CharacterWrap and This_very_long_unbroken_string_will_demonstrate_CharacterWrap, breakingmidword.")
                          .LineBreakMode(HeadTruncation);
                     c.Paragraph("CharacterWrap: This_very_long_unbroken_string_will_demonstrate_CharacterWrap and This_very_long_unbroken_string_will_demonstrate_CharacterWrap, breakingmidword.")

--- a/Test/MauiProgram.cs
+++ b/Test/MauiProgram.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Text;
+using Microsoft.Maui.Controls;
 
 namespace Test;
 public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
-        // Registrar el proveedor de codificación para Windows-1252
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
         var builder = MauiApp.CreateBuilder();

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -65,8 +65,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\MauiPdfGenerator.SourceGenerators\MauiPdfGenerator.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-	  <ProjectReference Include="..\MauiPdfGenerator\MauiPdfGenerator.csproj" />
+		<ProjectReference Include="..\MauiPdfGenerator.SourceGenerators\MauiPdfGenerator.SourceGenerators.csproj"
+					 OutputItemType="Analyzer"
+					 ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\MauiPdfGenerator\MauiPdfGenerator.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Se han realizado cambios significativos en `FontAliasGenerator.cs`, incluyendo nuevas directivas `using`, reestructuración de la clase y mejoras en la lógica para generar alias de fuentes, añadiendo fuentes estándar PDF Base14.

Se actualizó la versión del paquete en `MauiPdfGenerator.SourceGenerators.csproj` de `1.1.10` a `1.2.0` y se hicieron ajustes menores en la configuración del proyecto.

En `MainPage.xaml.cs`, se actualizaron las directivas `using` y se modificaron las propiedades de la interfaz de usuario para utilizar las fuentes adecuadas.

Se añadió una directiva `using` en `MauiProgram.cs` y se mantuvo la lógica de registro del proveedor de codificación.

Finalmente, se ajustaron las referencias en `Test.csproj` para asegurar que el proyecto de generadores de código se mantenga como un analizador y se mejoró la legibilidad del archivo.