### PR TITLE
Namespace Refactoring: Transition from 'Elements' to 'Views' for PDF-…

### DIFF
--- a/MauiPdfGenerator.Tests/MauiPdfGenerator/Fluent/Utils/StyleResolutionTests.cs
+++ b/MauiPdfGenerator.Tests/MauiPdfGenerator/Fluent/Utils/StyleResolutionTests.cs
@@ -1,9 +1,9 @@
 ﻿using MauiPdfGenerator.Common.Enums;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Common.Models.Styling;
 using MauiPdfGenerator.Diagnostics.Interfaces;
 using MauiPdfGenerator.Fluent.Builders;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Models;
 using MauiPdfGenerator.Fluent.Utils;
 using Moq;

--- a/MauiPdfGenerator/Common/Models/Views/PdfHorizontalLineData.cs
+++ b/MauiPdfGenerator/Common/Models/Views/PdfHorizontalLineData.cs
@@ -1,6 +1,6 @@
-﻿using MauiPdfGenerator.Common.Models.Styling;
+using MauiPdfGenerator.Common.Models.Styling;
 
-namespace MauiPdfGenerator.Common.Models.Elements;
+namespace MauiPdfGenerator.Common.Models.Views;
 
 internal class PdfHorizontalLineData : PdfElementData
 {

--- a/MauiPdfGenerator/Common/Models/Views/PdfImageData.cs
+++ b/MauiPdfGenerator/Common/Models/Views/PdfImageData.cs
@@ -1,6 +1,6 @@
-﻿using MauiPdfGenerator.Common.Models.Styling;
+using MauiPdfGenerator.Common.Models.Styling;
 
-namespace MauiPdfGenerator.Common.Models.Elements;
+namespace MauiPdfGenerator.Common.Models.Views;
 
 internal class PdfImageData : PdfElementData
 {

--- a/MauiPdfGenerator/Common/Models/Views/PdfParagraphData.cs
+++ b/MauiPdfGenerator/Common/Models/Views/PdfParagraphData.cs
@@ -1,8 +1,8 @@
-﻿using MauiPdfGenerator.Common.Enums;
+using MauiPdfGenerator.Common.Enums;
 using MauiPdfGenerator.Common.Models.Styling;
 using MauiPdfGenerator.Fluent.Models;
 
-namespace MauiPdfGenerator.Common.Models.Elements;
+namespace MauiPdfGenerator.Common.Models.Views;
 
 internal class PdfParagraphData : PdfElementData
 {

--- a/MauiPdfGenerator/Core/Implementation/Sk/Layouts/VerticalStackLayoutRenderer.cs
+++ b/MauiPdfGenerator/Core/Implementation/Sk/Layouts/VerticalStackLayoutRenderer.cs
@@ -1,5 +1,5 @@
-﻿using MauiPdfGenerator.Common.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Common.Models;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Common.Models.Layouts;
 using MauiPdfGenerator.Core.Implementation.Sk;
 using MauiPdfGenerator.Core.Models;

--- a/MauiPdfGenerator/Core/Implementation/Sk/SkComposer.cs
+++ b/MauiPdfGenerator/Core/Implementation/Sk/SkComposer.cs
@@ -1,6 +1,6 @@
-﻿using MauiPdfGenerator.Common.Models;
+using MauiPdfGenerator.Common.Models;
 using MauiPdfGenerator.Core.Exceptions;
-using MauiPdfGenerator.Core.Implementation.Sk.Elements;
+using MauiPdfGenerator.Core.Implementation.Sk.Views;
 using MauiPdfGenerator.Core.Implementation.Sk.Pages;
 using MauiPdfGenerator.Core.Models;
 using MauiPdfGenerator.Diagnostics.Interfaces;

--- a/MauiPdfGenerator/Core/Implementation/Sk/Views/ElementRendererFactory.cs
+++ b/MauiPdfGenerator/Core/Implementation/Sk/Views/ElementRendererFactory.cs
@@ -1,8 +1,8 @@
-﻿using MauiPdfGenerator.Core.Implementation.Sk.Layouts;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Core.Implementation.Sk.Layouts;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Common.Models.Layouts;
 
-namespace MauiPdfGenerator.Core.Implementation.Sk.Elements;
+namespace MauiPdfGenerator.Core.Implementation.Sk.Views;
 
 internal class ElementRendererFactory
 {

--- a/MauiPdfGenerator/Core/Implementation/Sk/Views/HorizontalLineRenderer.cs
+++ b/MauiPdfGenerator/Core/Implementation/Sk/Views/HorizontalLineRenderer.cs
@@ -1,9 +1,9 @@
-﻿using MauiPdfGenerator.Core.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Core.Models;
+using MauiPdfGenerator.Common.Models.Views;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 
-namespace MauiPdfGenerator.Core.Implementation.Sk.Elements;
+namespace MauiPdfGenerator.Core.Implementation.Sk.Views;
 
 internal class HorizontalLineRenderer : IElementRenderer
 {

--- a/MauiPdfGenerator/Core/Implementation/Sk/Views/ImageRenderer.cs
+++ b/MauiPdfGenerator/Core/Implementation/Sk/Views/ImageRenderer.cs
@@ -1,5 +1,5 @@
-﻿using MauiPdfGenerator.Core.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Core.Models;
+using MauiPdfGenerator.Common.Models.Views;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using MauiPdfGenerator.Diagnostics;
@@ -7,7 +7,7 @@ using MauiPdfGenerator.Diagnostics.Enums;
 using MauiPdfGenerator.Diagnostics.Models;
 using System.Diagnostics;
 
-namespace MauiPdfGenerator.Core.Implementation.Sk.Elements;
+namespace MauiPdfGenerator.Core.Implementation.Sk.Views;
 
 internal class ImageRenderer : IElementRenderer
 {

--- a/MauiPdfGenerator/Core/Implementation/Sk/Views/TextRenderer.cs
+++ b/MauiPdfGenerator/Core/Implementation/Sk/Views/TextRenderer.cs
@@ -1,5 +1,5 @@
-﻿using System.Diagnostics;
-using MauiPdfGenerator.Common.Models.Elements;
+using System.Diagnostics;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Common.Utils;
 using MauiPdfGenerator.Core.Models;
 using MauiPdfGenerator.Diagnostics;
@@ -9,7 +9,7 @@ using MauiPdfGenerator.Fluent.Models;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 
-namespace MauiPdfGenerator.Core.Implementation.Sk.Elements;
+namespace MauiPdfGenerator.Core.Implementation.Sk.Views;
 
 internal class TextRenderer : IElementRenderer
 {

--- a/MauiPdfGenerator/Core/Models/PdfGenerationContext.cs
+++ b/MauiPdfGenerator/Core/Models/PdfGenerationContext.cs
@@ -1,5 +1,5 @@
-﻿using MauiPdfGenerator.Common.Models;
-using MauiPdfGenerator.Core.Implementation.Sk.Elements;
+using MauiPdfGenerator.Common.Models;
+using MauiPdfGenerator.Core.Implementation.Sk.Views;
 using MauiPdfGenerator.Diagnostics.Interfaces;
 using MauiPdfGenerator.Fluent.Builders;
 using Microsoft.Extensions.Logging;

--- a/MauiPdfGenerator/Fluent/Builders/Layouts/Grids/PdfGridChildImplementations.cs
+++ b/MauiPdfGenerator/Fluent/Builders/Layouts/Grids/PdfGridChildImplementations.cs
@@ -1,7 +1,7 @@
-﻿﻿using MauiPdfGenerator.Fluent.Builders.Elements;
+using MauiPdfGenerator.Fluent.Builders.Views;
 using MauiPdfGenerator.Fluent.Interfaces;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 using MauiPdfGenerator.Fluent.Models;

--- a/MauiPdfGenerator/Fluent/Builders/Layouts/Grids/PdfGridChildrenBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/Layouts/Grids/PdfGridChildrenBuilder.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Builders.Elements;
+using MauiPdfGenerator.Fluent.Builders.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;

--- a/MauiPdfGenerator/Fluent/Builders/PageContentBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/PageContentBuilder.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Builders.Elements;
+using MauiPdfGenerator.Fluent.Builders.Views;
 using MauiPdfGenerator.Fluent.Builders.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;

--- a/MauiPdfGenerator/Fluent/Builders/PdfContentPageBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/PdfContentPageBuilder.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Common.Models;
+using MauiPdfGenerator.Common.Models;
 using MauiPdfGenerator.Common.Models.Styling;
 using MauiPdfGenerator.Common.Utils;
 using MauiPdfGenerator.Fluent.Builders.Layouts;
@@ -23,11 +23,11 @@ internal class PdfContentPageBuilder<TContent> : IPdfConfigurablePage<TContent>,
     private Color? _backgroundColorOverride;
     private PageOrientationType? _pageOrientationOverride;
     private PdfFontIdentifier? _pageDefaultFontFamily;
-    private float _pageDefaultFontSize = Common.Models.Elements.PdfParagraphData.DefaultFontSize;
-    private Color _pageDefaultTextColor = Common.Models.Elements.PdfParagraphData.DefaultTextColor;
-    private FontAttributes _pageDefaultFontAttributes = Common.Models.Elements.PdfParagraphData.DefaultFontAttributes;
-    private TextDecorations _pageDefaultTextDecorations = Common.Models.Elements.PdfParagraphData.DefaultTextDecorations;
-    private TextTransform _pageDefaultTextTransform = Common.Models.Elements.PdfParagraphData.DefaultTextTransform;
+    private float _pageDefaultFontSize = Common.Models.Views.PdfParagraphData.DefaultFontSize;
+    private Color _pageDefaultTextColor = Common.Models.Views.PdfParagraphData.DefaultTextColor;
+    private FontAttributes _pageDefaultFontAttributes = Common.Models.Views.PdfParagraphData.DefaultFontAttributes;
+    private TextDecorations _pageDefaultTextDecorations = Common.Models.Views.PdfParagraphData.DefaultTextDecorations;
+    private TextTransform _pageDefaultTextTransform = Common.Models.Views.PdfParagraphData.DefaultTextTransform;
 
     public PdfResourceDictionary PageResources { get; } = new(); 
 
@@ -62,7 +62,7 @@ internal class PdfContentPageBuilder<TContent> : IPdfConfigurablePage<TContent>,
     public IPdfConfigurablePage<TContent> Padding(float leftPadding, float topPadding, float rightPadding, float bottomPadding) { _paddingOverride = new Thickness(leftPadding, topPadding, rightPadding, bottomPadding); return this; }
     public IPdfConfigurablePage<TContent> Padding(DefaultPagePaddingType defaultPaddingType) { _paddingOverride = PdfPagePaddingTypeCalculator.GetThickness(defaultPaddingType); return this; }
     public IPdfConfigurablePage<TContent> BackgroundColor(Color backgroundColor) { _backgroundColorOverride = backgroundColor; return this; }
-    public IPdfConfigurablePage<TContent> DefaultTextColor(Color color) { _pageDefaultTextColor = color ?? Common.Models.Elements.PdfParagraphData.DefaultTextColor; return this; }
+    public IPdfConfigurablePage<TContent> DefaultTextColor(Color color) { _pageDefaultTextColor = color ?? Common.Models.Views.PdfParagraphData.DefaultTextColor; return this; }
     public IPdfConfigurablePage<TContent> DefaultTextDecorations(TextDecorations decorations) { _pageDefaultTextDecorations = decorations; return this; }
     public IPdfConfigurablePage<TContent> DefaultTextTransform(TextTransform transform) { _pageDefaultTextTransform = transform; return this; }
     public IPdfConfigurablePage<TContent> DefaultFont(Action<IPdfFontDefaultsBuilder> fontDefaults)

--- a/MauiPdfGenerator/Fluent/Builders/PdfStackLayoutContentBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/PdfStackLayoutContentBuilder.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Builders.Elements;
+using MauiPdfGenerator.Fluent.Builders.Views;
 using MauiPdfGenerator.Fluent.Builders.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;

--- a/MauiPdfGenerator/Fluent/Builders/Views/PdfHorizontalLineBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/Views/PdfHorizontalLineBuilder.cs
@@ -1,15 +1,15 @@
-﻿using MauiPdfGenerator.Common.Enums;
+using MauiPdfGenerator.Common.Enums;
 using MauiPdfGenerator.Common.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Fluent.Interfaces;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 using MauiPdfGenerator.Fluent.Interfaces.Pages;
 using MauiPdfGenerator.Fluent.Models;
 
-namespace MauiPdfGenerator.Fluent.Builders.Elements;
+namespace MauiPdfGenerator.Fluent.Builders.Views;
 
 internal class PdfHorizontalLineBuilder : IBuildablePdfElement, IPdfPageChildHorizontalLine, IPdfLayoutChildHorizontalLine, IPdfGridChildHorizontalLine, IPdfHorizontalLine
 {

--- a/MauiPdfGenerator/Fluent/Builders/Views/PdfImageBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/Views/PdfImageBuilder.cs
@@ -1,15 +1,15 @@
-﻿using MauiPdfGenerator.Common.Enums;
+using MauiPdfGenerator.Common.Enums;
 using MauiPdfGenerator.Common.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Fluent.Interfaces;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 using MauiPdfGenerator.Fluent.Interfaces.Pages;
 using MauiPdfGenerator.Fluent.Models;
 
-namespace MauiPdfGenerator.Fluent.Builders.Elements;
+namespace MauiPdfGenerator.Fluent.Builders.Views;
 
 internal class PdfImageBuilder : IBuildablePdfElement, IPdfPageChildImage, IPdfLayoutChildImage, IPdfGridChildImage, IPdfImage
 {
@@ -58,7 +58,7 @@ internal class PdfImageBuilder : IBuildablePdfElement, IPdfPageChildImage, IPdfL
     IPdfImage IPdfElement<IPdfImage>.BackgroundColor(Color? c) { BackgroundColor(c); return this; }
 
     // IPdfPageChildImage
-    IPdfPageChildImage Interfaces.Elements.IPdfImage<IPdfPageChildImage>.Aspect(Aspect a) { Aspect(a); return this; }
+    IPdfPageChildImage IPdfImage<IPdfPageChildImage>.Aspect(Aspect a) { Aspect(a); return this; }
     IPdfPageChildImage IPdfElement<IPdfPageChildImage>.Style(PdfStyleIdentifier k) { Style(k); return this; }
     IPdfPageChildImage IPdfElement<IPdfPageChildImage>.Margin(double u) { Margin(u); return this; }
     IPdfPageChildImage IPdfElement<IPdfPageChildImage>.Margin(double h, double v) { Margin(h, v); return this; }
@@ -71,7 +71,7 @@ internal class PdfImageBuilder : IBuildablePdfElement, IPdfPageChildImage, IPdfL
     IPdfPageChildImage IPdfElement<IPdfPageChildImage>.BackgroundColor(Color? c) { BackgroundColor(c); return this; }
 
     // IPdfLayoutChildImage
-    IPdfLayoutChildImage Interfaces.Elements.IPdfImage<IPdfLayoutChildImage>.Aspect(Aspect a) { Aspect(a); return this; }
+    IPdfLayoutChildImage IPdfImage<IPdfLayoutChildImage>.Aspect(Aspect a) { Aspect(a); return this; }
     IPdfLayoutChildImage IPdfElement<IPdfLayoutChildImage>.Style(PdfStyleIdentifier k) { Style(k); return this; }
     IPdfLayoutChildImage IPdfElement<IPdfLayoutChildImage>.Margin(double u) { Margin(u); return this; }
     IPdfLayoutChildImage IPdfElement<IPdfLayoutChildImage>.Margin(double h, double v) { Margin(h, v); return this; }
@@ -86,7 +86,7 @@ internal class PdfImageBuilder : IBuildablePdfElement, IPdfPageChildImage, IPdfL
     IPdfLayoutChildImage IPdfLayoutChild<IPdfLayoutChildImage>.VerticalOptions(LayoutAlignment a) { VerticalOptions(a); return this; }
 
     // IPdfGridChildImage
-    IPdfGridChildImage Interfaces.Elements.IPdfImage<IPdfGridChildImage>.Aspect(Aspect a) { Aspect(a); return this; }
+    IPdfGridChildImage IPdfImage<IPdfGridChildImage>.Aspect(Aspect a) { Aspect(a); return this; }
     IPdfGridChildImage IPdfElement<IPdfGridChildImage>.Style(PdfStyleIdentifier k) { Style(k); return this; }
     IPdfGridChildImage IPdfElement<IPdfGridChildImage>.Margin(double u) { Margin(u); return this; }
     IPdfGridChildImage IPdfElement<IPdfGridChildImage>.Margin(double h, double v) { Margin(h, v); return this; }

--- a/MauiPdfGenerator/Fluent/Builders/Views/PdfParagraphBuilder.cs
+++ b/MauiPdfGenerator/Fluent/Builders/Views/PdfParagraphBuilder.cs
@@ -1,16 +1,16 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using MauiPdfGenerator.Common.Enums;
 using MauiPdfGenerator.Common.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Fluent.Interfaces;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 using MauiPdfGenerator.Fluent.Interfaces.Pages;
 using MauiPdfGenerator.Fluent.Models;
 
-namespace MauiPdfGenerator.Fluent.Builders.Elements;
+namespace MauiPdfGenerator.Fluent.Builders.Views;
 
 internal class PdfParagraphBuilder : IBuildablePdfElement, IPdfPageChildParagraph, IPdfLayoutChildParagraph, IPdfGridChildParagraph, IPdfParagraph
 {

--- a/MauiPdfGenerator/Fluent/Interfaces/Layouts/Grids/IPdfGridChildHorizontalLine.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Layouts/Grids/IPdfGridChildHorizontalLine.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Layouts/Grids/IPdfGridChildImage.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Layouts/Grids/IPdfGridChildImage.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Layouts/Grids/IPdfGridChildParagraph.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Layouts/Grids/IPdfGridChildParagraph.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Layouts.Grids;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Layouts/IPdfLayoutChildHorizontalLine.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Layouts/IPdfLayoutChildHorizontalLine.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Layouts;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Layouts/IPdfLayoutChildImage.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Layouts/IPdfLayoutChildImage.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Layouts;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Layouts/IPdfLayoutChildParagraph.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Layouts/IPdfLayoutChildParagraph.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Layouts;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Pages/IPdfPageChildHorizontalLine.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Pages/IPdfPageChildHorizontalLine.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Pages;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Pages/IPdfPageChildImage.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Pages/IPdfPageChildImage.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Pages;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Pages/IPdfPageChildParagraph.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Pages/IPdfPageChildParagraph.cs
@@ -1,4 +1,4 @@
-﻿using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 
 namespace MauiPdfGenerator.Fluent.Interfaces.Pages;
 

--- a/MauiPdfGenerator/Fluent/Interfaces/Views/IPdfHorizontalLine.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Views/IPdfHorizontalLine.cs
@@ -1,4 +1,4 @@
-﻿namespace MauiPdfGenerator.Fluent.Interfaces.Elements;
+namespace MauiPdfGenerator.Fluent.Interfaces.Views;
 
 public interface IPdfHorizontalLine<TSelf> : IPdfElement<TSelf> where TSelf : IPdfElement<TSelf>
 {

--- a/MauiPdfGenerator/Fluent/Interfaces/Views/IPdfImage.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Views/IPdfImage.cs
@@ -1,4 +1,4 @@
-﻿namespace MauiPdfGenerator.Fluent.Interfaces.Elements;
+namespace MauiPdfGenerator.Fluent.Interfaces.Views;
 
 public interface IPdfImage<TSelf> : IPdfElement<TSelf> where TSelf : IPdfElement<TSelf>
 {

--- a/MauiPdfGenerator/Fluent/Interfaces/Views/IPdfParagraph.cs
+++ b/MauiPdfGenerator/Fluent/Interfaces/Views/IPdfParagraph.cs
@@ -1,6 +1,6 @@
-﻿using MauiPdfGenerator.Fluent.Models;
+using MauiPdfGenerator.Fluent.Models;
 
-namespace MauiPdfGenerator.Fluent.Interfaces.Elements;
+namespace MauiPdfGenerator.Fluent.Interfaces.Views;
 
 public interface IPdfParagraph<TSelf> : IPdfElement<TSelf> where TSelf : IPdfElement<TSelf>
 {

--- a/MauiPdfGenerator/Fluent/Utils/StyleResolver.cs
+++ b/MauiPdfGenerator/Fluent/Utils/StyleResolver.cs
@@ -1,6 +1,6 @@
 using MauiPdfGenerator.Common.Enums;
 using MauiPdfGenerator.Common.Models;
-using MauiPdfGenerator.Common.Models.Elements;
+using MauiPdfGenerator.Common.Models.Views;
 using MauiPdfGenerator.Common.Models.Layouts;
 using MauiPdfGenerator.Common.Models.Styling;
 using MauiPdfGenerator.Diagnostics;
@@ -8,10 +8,10 @@ using MauiPdfGenerator.Diagnostics.Enums;
 using MauiPdfGenerator.Diagnostics.Interfaces;
 using MauiPdfGenerator.Diagnostics.Models;
 using MauiPdfGenerator.Fluent.Builders;
-using MauiPdfGenerator.Fluent.Builders.Elements;
+using MauiPdfGenerator.Fluent.Builders.Views;
 using MauiPdfGenerator.Fluent.Builders.Layouts;
 using MauiPdfGenerator.Fluent.Interfaces.Builders;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Models;
 

--- a/Sample/MainPage.xaml.cs
+++ b/Sample/MainPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using MauiPdfGenerator;
 using MauiPdfGenerator.Fluent.Enums;
-using MauiPdfGenerator.Fluent.Interfaces.Elements;
+using MauiPdfGenerator.Fluent.Interfaces.Views;
 using MauiPdfGenerator.Fluent.Interfaces.Layouts;
 using MauiPdfGenerator.Fluent.Models;
 using MauiPdfGenerator.Fonts;


### PR DESCRIPTION
…visible objects (Related to issue #78)

- Removed outdated files and their associated renderers.
- Updated imports and references across builders, interfaces, tests, and other relevant files to adopt 'Views' in place of 'Elements'.
- Introduced new Views directories to support the updated structure.
- Applied minor adjustments to ensure full alignment with the revised namespace.